### PR TITLE
added NIST CVE analyzer details

### DIFF
--- a/docs/IntelOwl/usage.md
+++ b/docs/IntelOwl/usage.md
@@ -60,6 +60,7 @@ The following is the list of the available analyzers you can run out-of-the-box.
 ###### Internal tools
 
 - `APKiD`: [APKiD](https://github.com/rednaga/APKiD) identifies many compilers, packers, obfuscators, and other weird stuff from an APK or DEX file.
+- `Androguard` : [Androguard](https://github.com/androguard/androguard) is a python tool which can be leveraged to get useful information from the APK, for example, permissions, activities, services, 3rd party permissions, etc.
 - `BoxJS_Scan_Javascript`: [Box-JS](https://github.com/CapacitorSet/box-js) is a tool for studying JavaScript malware.
 - `Capa_Info`: [Capa](https://github.com/mandiant/capa) detects capabilities in executable files
 - `Capa_Info_Shellcode`: [Capa](https://github.com/mandiant/capa) detects capabilities in shellcode

--- a/docs/IntelOwl/usage.md
+++ b/docs/IntelOwl/usage.md
@@ -274,6 +274,7 @@ Some analyzers require details other than just IP, URL, Domain, etc. We classifi
 - `YARAify_Generics`: lookup a YARA rule (default), ClamAV rule, imphash, TLSH, telfhash or icon_dash in [YARAify](https://yaraify.abuse.ch/)
 - `PhoneInfoga` : [PhoneInfoga](https://sundowndev.github.io/phoneinfoga/) is one of the most advanced tools to scan international phone numbers.
 - `HudsonRock`: [Hudson Rock](https://cavalier.hudsonrock.com/docs) provides its clients the ability to query a database of over 27,541,128 computers which were compromised through global info-stealer campaigns performed by threat actors.
+- `NIST_CVE_DB`: [NIST_CVE_DB](https://nvd.nist.gov/developers/start-here) provides the details of supplied CVE Id.
 
 ##### Optional analyzers
 


### PR DESCRIPTION
The NIST CVE analyzer details have been added under **Generic Analyzer** in **External Services** section.