### PR TITLE
docs(GreedyBear): Update for Ruff migration and expand API documentation

### DIFF
--- a/docs/GreedyBear/Api-docs.md
+++ b/docs/GreedyBear/Api-docs.md
@@ -42,6 +42,8 @@ _Note: Enhanced with additional filter fields (ioc_type, etc.) in version > 2.4.
 ### `IOCSerializer`
 :::docs.Submodules.GreedyBear.api.serializers.IOCSerializer
 
+_Note: Includes FireHol categories field in version > 2.4.0_
+
 ### `GeneralHoneypotSerializer`
 :::docs.Submodules.GreedyBear.api.serializers.GeneralHoneypotSerializer
 

--- a/docs/GreedyBear/Contribute.md
+++ b/docs/GreedyBear/Contribute.md
@@ -34,8 +34,6 @@ Keeping to a consistent code style throughout the project makes it easier to con
   - flake8-comprehensions (C4) - List/dict comprehension improvements
   - flake8-django (DJ) - Django-specific best practices
 
-Ruff is significantly faster than the previous toolchain while maintaining compatibility with existing code style.
-
 ## How to start (Setup project and development instance)
 
 To start with the development setup, make sure you go through all the steps in [Installation Guide](https://intelowlproject.github.io/docs/GreedyBear/Installation/) and properly installed it.


### PR DESCRIPTION
## Description

Update GreedyBear documentation to reflect Ruff migration (PR #663) and expand API documentation coverage.

## Changes

### Contribute.md
- Update Code Style section to reflect Ruff migration from black/isort/flake8
- Add detailed Ruff capabilities and rule sets documentation
- Add manual Ruff command examples for contributors

### Api-docs.md
- Add missing Cowrie Session API endpoint documentation
- Add comprehensive Serializers section (EnrichmentSerializer, FeedsRequestSerializer, etc.)
- Add Validation Functions section (feed_type_validation, ordering_validation)
- Improve organization with clear section headers
- Fix naming consistency (general_honeypot_list → General Honeypot List)
- Add version note for upcoming FeedsRequestSerializer enhancements

## Related PRs

- intelowlproject/GreedyBear#663: Migrate from flake8/black/isort to Ruff (pending merge)

## Notes

- **Cowrie Session endpoint**: Already available in main branch
- **Most serializers**: Already available in main branch  
- **FeedsRequestSerializer enhancements**: _Available from version > 2.4.0_ (currently in develop, will auto-update via submodule sync when merged to main)

## Checklist

- [x] The pull request is for the branch `main`
- [x] If I added new documentation related to a new Pull Request that I created, I have added a reference to the related Pull Request
  - [x] If the new documentation will be added in a future release, please add a reference like `_Available from version > x.x.x_` where x.x.x is the current version number
- [ ] If the additional documentation is a fix, you should directly push to the `main` branch and do not open this PR.