### PR TITLE
[GSoC 2026] docs(chatbot): latency numbers

### DIFF
--- a/docs/IntelOwl/chatbot_tuning.md
+++ b/docs/IntelOwl/chatbot_tuning.md
@@ -25,10 +25,20 @@ Two consequences matter for tuning:
 ## Choosing a model
 
 The default is **`qwen2.5:3b`**. It is chosen on purpose: it is the smallest model that reliably
-picks the right tool and answers from the tool output with **usable latency on a CPU-only deploy**
-(for comparison, a 7B model such as `mistral` was markedly slower on CPU — minutes per agent round,
-often hitting the turn timeout). On stronger
-hardware you can switch to any larger tool-capable Ollama model for better answer quality.
+picks the right tool and answers from the tool output with **usable latency on a CPU-only deploy**.
+Measured end-to-end on a 14-thread CPU (no GPU), warm:
+
+- a plain answer that needs no tool returns in **~5–6 s** (first token in ~0.3 s);
+- a tool-backed answer returns in **~30–50 s** (first token in ~5–13 s, then it streams in).
+
+The first request after the model has been idle (Ollama unloads it after ~5 min) pays a one-time
+**~70 s** cold-load to read the model back into memory; later turns are warm again.
+
+Bigger is not automatically better: in the same measurement a 7B model (`mistral`) **did not emit any
+tool calls on this stack** and replied with invented data instead, so `qwen2.5:3b` is the default for
+**tool-calling reliability**, not only speed. On stronger hardware you can move to any larger
+tool-capable Ollama model — but confirm it actually calls tools (see
+[Validating a model](#validating-a-model-before-rollout)).
 
 Requirements for a replacement model:
 


### PR DESCRIPTION
# Description

Follow-up to #65 (chatbot docs): adds the citable end-to-end latency numbers from the W10 latency
benchmark to the Fine-tuning & Prompting guide ("Choosing a model").

- **`chatbot_tuning.md` ("Choosing a model")**: replaces the qualitative latency text with measured
  warm numbers (no-tool ~5–6 s, tool-backed ~30–50 s, first token ~0.3–13 s) and the one-time ~70 s
  cold-load. States the empirical finding that a 7B model (`mistral`) **did not emit tool calls on
  this stack** (it answered with invented data) — so `qwen2.5:3b` is the default for **tool-calling
  reliability**, not only speed.

The `_Available from version >= 6.7.0_` availability note is already on `main` (added in #65), so this
PR only adds the latency numbers.

Numbers come from a live end-to-end benchmark (real Ollama, no mocks, CPU-only): `qwen2.5:3b`
(3.1B, Q4_K_M) vs `mistral:latest` (7.2B, Q4_K_M).

Refs intelowlproject/IntelOwl#3810

# Checklist

- [x] The pull request is for the branch `main`
- [x] I added documentation related to existing work and referenced it (follow-up to #65; Refs intelowlproject/IntelOwl#3810)
  - [x] Availability is already indicated on `main` (`_Available from version >= 6.7.0_`, added in #65)
- [ ] N/A — this is additive documentation, not a fix, so it is opened as a PR (not pushed directly to `main`)
