### PR TITLE
[GSoC 2026] docs(chatbot): fix stale agent API reference (create_agent)

### DIFF
--- a/docs/IntelOwl/contribute.md
+++ b/docs/IntelOwl/contribute.md
@@ -652,7 +652,7 @@ def build_tools(user) -> list:
 
 Add a one-line entry under `[Tools — when to use each]` in
 `api_app/chatbot_manager/agent/system_prompt.txt`. The agent binds the tools through
-`create_tool_calling_agent`; that line is how the model learns when to reach for yours. See the
+`create_agent`; that line is how the model learns when to reach for yours. See the
 [Fine-tuning & Prompting](./chatbot_tuning.md) guide for the prompt structure.
 
 ### 5. Test it


### PR DESCRIPTION
The developer guide ("How to add a chatbot tool") said the agent binds tools through
  `create_tool_calling_agent`, which was removed in the LangChain 1.x migration
  (intelowlproject/IntelOwl#3842). The current engine binds tools through `create_agent` (LangGraph
  runtime), see `api_app/chatbot_manager/agent/agent.py`. One-line correctness fix; no other content
  changed.